### PR TITLE
Update openCv4 version to 3.3.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,7 +41,7 @@ android {
 
 dependencies {
     implementation 'com.google.zxing:core:3.0.1'
-    implementation 'com.github.eliasteeny:opencv_android_module:3.1.0-fix3'
+    implementation 'com.github.davidmigloz:opencv-android-gradle-repo:3.3.0'
     implementation project(path: ':flutter_plugin_android_lifecycle')
 
 }


### PR DESCRIPTION
Hi! I'm using this package in combination with [EdgeDetection](https://pub.dev/packages/edge_detection) and I've come across a dependency duplicate exception. 

OpenCv4 was the problem, both packages use a different version. The version in this package was 3.1.0 so I fixed the exception by using the 3.3.0 version instead. Thought that someone may also need the newer version in the future. 